### PR TITLE
Update cache file location to support awscli 1.14+

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ If you defined AWS profiles in ~/.aws/credentials and ~/.aws/config the script w
 
 ## Dependencies
 
-The AWS cli (>= 1.10.18) and jq must be installed on your system.
+The AWS cli (>= 1.14) and jq must be installed on your system.
 
 ```
 pip install awscli

--- a/aws-auth.sh
+++ b/aws-auth.sh
@@ -11,7 +11,8 @@ if [ -n "$AWS_PROFILE" ]; then
   source_profile="$(aws configure get source_profile --profile "$AWS_PROFILE" || echo "")"
   if [ -n "$source_profile" ]; then
     role_arn="$(aws configure get role_arn --profile "$AWS_PROFILE")"
-    cache_file=${CACHE_DIR}/${AWS_PROFILE}--$(echo "$role_arn" | sed 's/:/_/g' | sed 's/\//-/g').json
+    mfa_serial="$(aws configure get mfa_serial --profile "$AWS_PROFILE")"
+    cache_file=${CACHE_DIR}/$(echo -n "{\"RoleArn\": \"$role_arn\", \"SerialNumber\": \"$mfa_serial\"}" | openssl dgst -sha1).json
     AWS_DEFAULT_REGION=$(aws configure get region --profile "$source_profile" || echo "")
     AWS_ACCESS_KEY_ID="$(cat $cache_file | jq -r ".Credentials.AccessKeyId")"
     AWS_SECRET_ACCESS_KEY="$(cat $cache_file | jq -r ".Credentials.SecretAccessKey")"


### PR DESCRIPTION
As described in #1 awscli has change the internal cache file names and is using a sha1 hash of the serialized arguments used to assume the role. Since we're always using the same sts call to generate the session we can recreate the JSON string to derive the hash used in the cache file name.