### PR TITLE
pipe openssl sha1 output through `cut` to nullify difference in output between openssl versions

### DIFF
--- a/aws-auth.sh
+++ b/aws-auth.sh
@@ -12,7 +12,7 @@ if [ -n "$AWS_PROFILE" ]; then
   if [ -n "$source_profile" ]; then
     role_arn="$(aws configure get role_arn --profile "$AWS_PROFILE")"
     mfa_serial="$(aws configure get mfa_serial --profile "$AWS_PROFILE")"
-    cache_file=${CACHE_DIR}/$(echo -n "{\"RoleArn\": \"$role_arn\", \"SerialNumber\": \"$mfa_serial\"}" | openssl dgst -sha1).json
+    cache_file=${CACHE_DIR}/$(echo -n "{\"RoleArn\": \"$role_arn\", \"SerialNumber\": \"$mfa_serial\"}" | openssl dgst -sha1 | cut -d " " -f 2).json
     AWS_DEFAULT_REGION=$(aws configure get region --profile "$source_profile" || echo "")
     AWS_ACCESS_KEY_ID="$(cat $cache_file | jq -r ".Credentials.AccessKeyId")"
     AWS_SECRET_ACCESS_KEY="$(cat $cache_file | jq -r ".Credentials.SecretAccessKey")"


### PR DESCRIPTION
While #2 solved *most of* the problem, non-macos openssl appears to prefix hashes calculated over the stdin with `(stdin)= ` whereas macos' openssl seems to omit that.

Fix this with a bit of `cut` magic.

Could people please check this version works for them?